### PR TITLE
Add more details on how to deploy to IBM Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ### Backend for the starter applications of IoT4I
 
 #### How to run in IBM Cloud
+- Click the Deploy to IBM Cloud button to create the three applications in the IBM Cloud.  Accept the defaults or edit the name of the toolchain and Git repos/applications/space.  
+- Use the US-South region.  If another region is chosen, edit the `domain` setting in each application's `manifest.yml`. 
+- After the deploy, edit the Dashboard and Policy Holder applications to set the tenant id in `app\config-$ENV.js`, where `$ENV` is the environment variable which defaults to `staging`.
+
 ##### Deploy through IBM Cloud Continuous Delivery
 
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/ibm-watson-iot/ioti-starter-app-backend)


### PR DESCRIPTION
Specify it should be US-South as it fails by default to any other region
Note the default names can be edited and the tenant id must be manually added